### PR TITLE
vm service registration initialization

### DIFF
--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -64,7 +64,7 @@ class LoggingService {
   /// flutter foundation binding (see e.g., https://github.com/flutter/flutter/pull/21505).
   void initServiceExtensions() {
     _registerServiceExtension(
-        name: 'ext.flutter.logging',
+        name: 'ext.flutter.logs.enable',
         callback: (Map<String, Object> parameters) async {
           final String channel = parameters['channel'];
           if (channel != null) {
@@ -75,7 +75,7 @@ class LoggingService {
           return <String, dynamic>{};
         });
     _registerServiceExtension(
-        name: 'ext.flutter.loggingChannels',
+        name: 'ext.flutter.logs.loggingChannels',
         callback: (Map<String, dynamic> parameters) async => _channels
             .map((channel, description) => MapEntry(channel, <String, String>{
                   'enabled': shouldLog(channel).toString(),

--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -64,7 +64,7 @@ class LoggingService {
   /// flutter foundation binding (see e.g., https://github.com/flutter/flutter/pull/21505).
   void initServiceExtensions() {
     _registerServiceExtension(
-        name: 'logs.enable',
+        name: 'enable',
         callback: (Map<String, Object> parameters) async {
           final String channel = parameters['channel'];
           if (channel != null) {
@@ -75,7 +75,7 @@ class LoggingService {
           return <String, dynamic>{};
         });
     _registerServiceExtension(
-        name: 'logs.loggingChannels',
+        name: 'loggingChannels',
         callback: (Map<String, dynamic> parameters) async => _channels
             .map((channel, description) => MapEntry(channel, <String, String>{
                   'enabled': shouldLog(channel).toString(),
@@ -111,7 +111,7 @@ class LoggingService {
       {@required String name, @required _ServiceExtensionCallback callback}) {
     assert(name != null);
     assert(callback != null);
-    final String methodName = 'ext.flutter.$name';
+    final String methodName = 'ext.flutter.logs.$name';
     developer.registerExtension(name,
         (String method, Map<String, String> parameters) async {
       assert(method == methodName);

--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -64,7 +64,7 @@ class LoggingService {
   /// flutter foundation binding (see e.g., https://github.com/flutter/flutter/pull/21505).
   void initServiceExtensions() {
     _registerServiceExtension(
-        name: 'ext.flutter.logs.enable',
+        name: 'logs.enable',
         callback: (Map<String, Object> parameters) async {
           final String channel = parameters['channel'];
           if (channel != null) {
@@ -75,7 +75,7 @@ class LoggingService {
           return <String, dynamic>{};
         });
     _registerServiceExtension(
-        name: 'ext.flutter.logs.loggingChannels',
+        name: 'logs.loggingChannels',
         callback: (Map<String, dynamic> parameters) async => _channels
             .map((channel, description) => MapEntry(channel, <String, String>{
                   'enabled': shouldLog(channel).toString(),
@@ -111,9 +111,10 @@ class LoggingService {
       {@required String name, @required _ServiceExtensionCallback callback}) {
     assert(name != null);
     assert(callback != null);
+    final String methodName = 'ext.flutter.$name';
     developer.registerExtension(name,
         (String method, Map<String, String> parameters) async {
-      assert(method == name);
+      assert(method == methodName);
 
       dynamic caughtException;
       StackTrace caughtStack;

--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -64,7 +64,7 @@ class LoggingService {
   /// flutter foundation binding (see e.g., https://github.com/flutter/flutter/pull/21505).
   void initServiceExtensions() {
     _registerServiceExtension(
-        name: 'logging',
+        name: 'ext.flutter.logging',
         callback: (Map<String, Object> parameters) async {
           final String channel = parameters['channel'];
           if (channel != null) {
@@ -75,7 +75,7 @@ class LoggingService {
           return <String, dynamic>{};
         });
     _registerServiceExtension(
-        name: 'loggingChannels',
+        name: 'ext.flutter.loggingChannels',
         callback: (Map<String, dynamic> parameters) async => _channels
             .map((channel, description) => MapEntry(channel, <String, String>{
                   'enabled': shouldLog(channel).toString(),


### PR DESCRIPTION
Logging VM service call registrations.

This will allow us to easily test registration from the IDE end-to-end.  (Hopefully, medium-term, this will get inlined in the flutter foundation binding.)

/cc @devoncarew @jacob314