### PR TITLE
logData; logError

### DIFF
--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -90,10 +90,51 @@ class LoggingService {
     }
 
     assert(messageCallback != null);
-    final Object message = messageCallback();
+    final String message = messageCallback();
     assert(message != null);
 
-    _logMessageCallback(json.encode(message), channel);
+    _logMessageCallback(message, channel);
+  }
+
+  void logData(
+    String channel,
+    Object data, {
+    LogMessageCallback messageCallback,
+    Object toEncodable(Object nonEncodable),
+  }) {
+    assert(channel != null);
+    if (!shouldLog(channel)) {
+      return;
+    }
+
+    String message =
+        messageCallback != null ? messageCallback() : data.toString();
+    if (toEncodable != null) {
+      data = toEncodable(data);
+    }
+    developer.log(message, name: channel, error: data);
+  }
+
+  void logError(
+    String channel,
+    Object error, {
+    StackTrace stackTrace,
+    LogMessageCallback messageCallback,
+  }) {
+    assert(channel != null);
+    if (!shouldLog(channel)) {
+      return;
+    }
+
+    String message =
+        messageCallback != null ? messageCallback() : error.toString();
+    developer.log(
+      message,
+      name: channel,
+      level: 1000,
+      error: error,
+      stackTrace: stackTrace,
+    );
   }
 
   void registerChannel(String name, {String description}) {

--- a/lib/src/logs.dart
+++ b/lib/src/logs.dart
@@ -2,7 +2,7 @@ import 'package:logs/src/logging_service.dart';
 
 /// A callback that, when evaluated, returns a log message.  Log messages must
 /// be encodable as JSON using `json.encode()`.
-typedef LogMessageCallback = Object Function();
+typedef LogMessageCallback = String Function();
 
 /// Enable (or disable) logging for all events on the given [channel].
 void enableLogging(String channel, [bool enable = true]) {
@@ -63,5 +63,31 @@ class Log {
   /// @see [log]
   void log(LogMessageCallback messageCallback) {
     loggingService.log(channel, messageCallback);
+  }
+
+  void logData(
+    Object data, {
+    LogMessageCallback messageCallback,
+    Object toEncodable(Object nonEncodable),
+  }) {
+    loggingService.logData(
+      channel,
+      data,
+      messageCallback: messageCallback,
+      toEncodable: toEncodable,
+    );
+  }
+
+  void logError(
+    Object error, {
+    StackTrace stackTrace,
+    LogMessageCallback messageCallback,
+  }) {
+    loggingService.logError(
+      channel,
+      error,
+      messageCallback: messageCallback,
+      stackTrace: stackTrace,
+    );
   }
 }


### PR DESCRIPTION
Not for landing, but perhaps food for thought; this PR adds a data channel (`logData`) w/ the ability to generate a custom message to display for the log. Similarly with the `logError` call. Both try to delay work until after we've checked whether logging is enabled for that channel.

A final solution likely wouldn't have the same API but may have similar functionality (data, message, and error logging?).