### PR TITLE
data logging

### DIFF
--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -96,9 +96,8 @@ class LoggingService {
     final String message = messageCallback();
     assert(message != null);
 
-    String encodedData = data != null
-        ? json.encode(message, toEncodable: toJsonEncodable)
-        : null;
+    String encodedData =
+        data != null ? json.encode(data(), toEncodable: toJsonEncodable) : null;
     _logMessageCallback(message, channel, encodedData);
   }
 

--- a/lib/src/logging_service.dart
+++ b/lib/src/logging_service.dart
@@ -23,7 +23,8 @@ typedef _ServiceExtensionCallback = Future<Map<String, dynamic>> Function(
     Map<String, String> parameters);
 
 @visibleForTesting
-typedef DeveloperLogCallback = void Function(String message, String name);
+typedef DeveloperLogCallback = void Function(
+    String message, String name, Object data);
 
 /// Manages logging services.
 ///
@@ -40,8 +41,8 @@ class LoggingService {
 
   @visibleForTesting
   LoggingService()
-      : this.withCallback((String message, String name) {
-          developer.log(message, name: name);
+      : this.withCallback((String message, String name, Object data) {
+          developer.log(message, name: name, error: data);
         });
 
   @visibleForTesting
@@ -84,17 +85,21 @@ class LoggingService {
             });
   }
 
-  void log(String channel, LogMessageCallback messageCallback) {
+  void log(String channel, LogMessageCallback messageCallback,
+      {LogDataCallback data, ToJsonEncodable toJsonEncodable}) {
     assert(channel != null);
     if (!shouldLog(channel)) {
       return;
     }
 
     assert(messageCallback != null);
-    final Object message = messageCallback();
+    final String message = messageCallback();
     assert(message != null);
 
-    _logMessageCallback(json.encode(message), channel);
+    String encodedData = data != null
+        ? json.encode(message, toEncodable: toJsonEncodable)
+        : null;
+    _logMessageCallback(message, channel, encodedData);
   }
 
   void registerChannel(String name, {String description}) {

--- a/lib/src/logs.dart
+++ b/lib/src/logs.dart
@@ -40,7 +40,8 @@ void enableLogging(String channel, [bool enable = true]) {
 /// [debugEnableLogging] or using a VM service call.
 void log(String channel, LogMessageCallback messageCallback,
     {LogDataCallback data, ToJsonEncodable toJsonEncodable}) {
-  loggingService.log(channel, messageCallback);
+  loggingService.log(channel, messageCallback,
+      data: data, toJsonEncodable: toJsonEncodable);
 }
 
 /// Register a logging channel with the given [name] and optional [description].

--- a/test/service_test.dart
+++ b/test/service_test.dart
@@ -5,10 +5,13 @@ void main() {
   group('service tests', () {
     LoggingService service;
     String loggedResult;
+    Object loggedData;
 
     setUp(() {
-      service = LoggingService.withCallback((String message, String channel) {
+      service = LoggingService.withCallback(
+          (String message, String channel, Object data) {
         loggedResult = message;
+        loggedData = data;
       });
     });
 
@@ -55,14 +58,15 @@ void main() {
       service.registerChannel('foo');
       service.registerChannel('bar');
       service.registerChannel('baz');
-      expect(service.channelDescriptions.keys, containsAll(['foo', 'bar', 'baz']));
+      expect(
+          service.channelDescriptions.keys, containsAll(['foo', 'bar', 'baz']));
     });
 
     test('log', () {
       service.registerChannel('foo');
       service.enableLogging('foo', true);
       service.log('foo', () => 'bar');
-      expect(loggedResult, '"bar"');
+      expect(loggedResult, 'bar');
     });
   });
 }

--- a/test/service_test.dart
+++ b/test/service_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('service tests', () {
     LoggingService service;
     String loggedResult;
-    Object loggedData;
+    String loggedData;
 
     setUp(() {
       service = LoggingService.withCallback(
@@ -65,8 +65,14 @@ void main() {
     test('log', () {
       service.registerChannel('foo');
       service.enableLogging('foo', true);
-      service.log('foo', () => 'bar');
+      service.log('foo', () => 'bar',
+          data: () => {
+                'x': 1,
+                'y': 2,
+                'z': 3,
+              });
       expect(loggedResult, 'bar');
+      expect(loggedData, '{"x":1,"y":2,"z":3}');
     });
   });
 }


### PR DESCRIPTION
Follow-up from #19.

I opted to add `data` to the log call but we could add a `logData` call instead.  I don't have a strong preference...

(Aside: It'll be interesting to see how much of a drag all of these closures are in practice.)

/cc @devoncarew 