### PR TITLE
add http; tweak initialization

### DIFF
--- a/lib/src/channels/http_channel.dart
+++ b/lib/src/channels/http_channel.dart
@@ -1,0 +1,207 @@
+/// Simple WIP http channel based on POC in https://github.com/pq/logs/issues/6
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:logs/logs.dart';
+
+final _HttpOverrides _httpOverrides = _HttpOverrides();
+
+final Log _log = Log('http');
+
+/// Hook to install the http channel.
+void installHttpChannel() {
+  if (!_log.enabled) {
+    _log.enabled = true;
+  }
+
+  HttpOverrides.global = _httpOverrides;
+}
+
+class LoggingHttpClient implements HttpClient {
+  HttpClient proxy;
+
+  @override
+  Duration connectionTimeout;
+
+  @override
+  Duration idleTimeout;
+
+  @override
+  int maxConnectionsPerHost;
+
+  @override
+  String userAgent;
+
+  int count = 1;
+
+  LoggingHttpClient({SecurityContext context}) {
+    HttpOverrides.global = null;
+    proxy = HttpClient(context: context);
+    HttpOverrides.global = _httpOverrides;
+  }
+
+  @override
+  set authenticate(
+      Future<bool> Function(Uri url, String scheme, String realm) f) {
+    todo('authenticate');
+    proxy.authenticate = f;
+  }
+
+  @override
+  set authenticateProxy(
+      Future<bool> Function(String host, int port, String scheme, String realm)
+          f) {
+    todo('authenticateProxy');
+    proxy.authenticateProxy = f;
+  }
+
+  @override
+  bool get autoUncompress => proxy.autoUncompress;
+
+  set autoUncompress(bool value) {
+    proxy.autoUncompress = value;
+  }
+
+  @override
+  set badCertificateCallback(
+      bool Function(X509Certificate cert, String host, int port) callback) {
+    todo('badCertificateCallback');
+    proxy.badCertificateCallback = callback;
+  }
+
+  @override
+  set findProxy(String Function(Uri url) f) {
+    todo('findProxy');
+    proxy.findProxy = f;
+  }
+
+  @override
+  void addCredentials(
+      Uri url, String realm, HttpClientCredentials credentials) {
+    todo('addCredentials');
+    proxy.addCredentials(url, realm, credentials);
+  }
+
+  @override
+  void addProxyCredentials(
+      String host, int port, String realm, HttpClientCredentials credentials) {
+    todo('addProxyCredentials');
+    proxy.addProxyCredentials(host, port, realm, credentials);
+  }
+
+  @override
+  void close({bool force = false}) {
+    todo('close');
+    proxy.close(force: force);
+  }
+
+  @override
+  Future<HttpClientRequest> delete(String host, int port, String path) {
+    todo('delete');
+    return proxy.delete(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> deleteUrl(Uri url) {
+    todo('deleteUrl');
+    return proxy.deleteUrl(url);
+  }
+
+  @override
+  Future<HttpClientRequest> get(String host, int port, String path) {
+    _log.log(() => 'getUrl: $host $port $path');
+    return proxy.get(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) {
+    _log.log(() => 'getUrl: $url');
+    return proxy.getUrl(url);
+  }
+
+  @override
+  Future<HttpClientRequest> head(String host, int port, String path) {
+    todo('head');
+    return proxy.head(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> headUrl(Uri url) {
+    todo('headUrl');
+    return proxy.headUrl(url);
+  }
+
+  @override
+  Future<HttpClientRequest> open(
+      String method, String host, int port, String path) {
+    todo('open');
+    return proxy.open(method, host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) {
+    final int id = count++;
+
+    // #1 • GET • https://flutter.io open
+    _log.log(() => '#$id \u2022 $method \u2022 $url open');
+
+    Future<HttpClientRequest> request = proxy.openUrl(method, url);
+    return request.then((HttpClientRequest req) {
+      // todo (pq): consider putting id in sequence number?
+      _log.log(() => '#$id \u2022 $method \u2022 $url request ready');
+
+      req.done.then((HttpClientResponse response) {
+        _log.log(() =>
+            '#$id \u2022 $method \u2022 $url ${response.statusCode} ${response.reasonPhrase} ${response.contentLength} bytes');
+      });
+
+      return req;
+    });
+  }
+
+  @override
+  Future<HttpClientRequest> patch(String host, int port, String path) {
+    todo('patch');
+    return proxy.patch(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> patchUrl(Uri url) {
+    todo('patchUrl');
+    return proxy.patchUrl(url);
+  }
+
+  @override
+  Future<HttpClientRequest> post(String host, int port, String path) {
+    todo('post');
+    return proxy.post(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> postUrl(Uri url) {
+    todo('postUrl');
+    return proxy.postUrl(url);
+  }
+
+  @override
+  Future<HttpClientRequest> put(String host, int port, String path) {
+    todo('put');
+    return proxy.put(host, port, path);
+  }
+
+  @override
+  Future<HttpClientRequest> putUrl(Uri url) {
+    todo('putUrl');
+    return proxy.putUrl(url);
+  }
+}
+
+void todo(String msg) {
+  print('TODO: $msg');
+}
+
+class _HttpOverrides extends HttpOverrides {
+  HttpClient createHttpClient(SecurityContext context) =>
+      LoggingHttpClient(context: context);
+}

--- a/lib/src/channels/http_channel.dart
+++ b/lib/src/channels/http_channel.dart
@@ -1,5 +1,4 @@
 /// Simple WIP http channel based on POC in https://github.com/pq/logs/issues/6
-
 import 'dart:async';
 import 'dart:io';
 
@@ -18,22 +17,17 @@ void installHttpChannel() {
   HttpOverrides.global = _httpOverrides;
 }
 
+void _todo(String msg) {
+  print('todo: $msg');
+}
+
 class LoggingHttpClient implements HttpClient {
   HttpClient proxy;
 
   @override
-  Duration connectionTimeout;
-
-  @override
-  Duration idleTimeout;
-
-  @override
-  int maxConnectionsPerHost;
-
-  @override
   String userAgent;
 
-  int count = 1;
+  int _count = 1;
 
   LoggingHttpClient({SecurityContext context}) {
     HttpOverrides.global = null;
@@ -44,15 +38,15 @@ class LoggingHttpClient implements HttpClient {
   @override
   set authenticate(
       Future<bool> Function(Uri url, String scheme, String realm) f) {
-    todo('authenticate');
+    _todo('authenticate');
     proxy.authenticate = f;
   }
 
   @override
   set authenticateProxy(
-      Future<bool> Function(String host, int port, String scheme, String realm)
-          f) {
-    todo('authenticateProxy');
+    Future<bool> Function(String host, int port, String scheme, String realm) f,
+  ) {
+    _todo('authenticateProxy');
     proxy.authenticateProxy = f;
   }
 
@@ -66,94 +60,119 @@ class LoggingHttpClient implements HttpClient {
   @override
   set badCertificateCallback(
       bool Function(X509Certificate cert, String host, int port) callback) {
-    todo('badCertificateCallback');
+    _todo('badCertificateCallback');
     proxy.badCertificateCallback = callback;
   }
 
   @override
+  Duration get connectionTimeout => proxy.connectionTimeout;
+
+  @override
+  set connectionTimeout(Duration connectionTimeout) {
+    proxy.connectionTimeout = connectionTimeout;
+  }
+
+  @override
   set findProxy(String Function(Uri url) f) {
-    todo('findProxy');
+    _todo('findProxy');
     proxy.findProxy = f;
+  }
+
+  @override
+  Duration get idleTimeout => proxy.idleTimeout;
+
+  @override
+  set idleTimeout(Duration idleTimeout) {
+    proxy.idleTimeout = idleTimeout;
+  }
+
+  @override
+  int get maxConnectionsPerHost => proxy.maxConnectionsPerHost;
+
+  @override
+  set maxConnectionsPerHost(int maxConnectionsPerHost) {
+    proxy.maxConnectionsPerHost = maxConnectionsPerHost;
   }
 
   @override
   void addCredentials(
       Uri url, String realm, HttpClientCredentials credentials) {
-    todo('addCredentials');
+    _todo('addCredentials');
     proxy.addCredentials(url, realm, credentials);
   }
 
   @override
   void addProxyCredentials(
       String host, int port, String realm, HttpClientCredentials credentials) {
-    todo('addProxyCredentials');
+    _todo('addProxyCredentials');
     proxy.addProxyCredentials(host, port, realm, credentials);
   }
 
   @override
   void close({bool force = false}) {
-    todo('close');
+    _todo('close');
     proxy.close(force: force);
   }
 
   @override
   Future<HttpClientRequest> delete(String host, int port, String path) {
-    todo('delete');
+    _todo('delete');
     return proxy.delete(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> deleteUrl(Uri url) {
-    todo('deleteUrl');
+    _todo('deleteUrl');
     return proxy.deleteUrl(url);
   }
 
   @override
   Future<HttpClientRequest> get(String host, int port, String path) {
-    _log.log(() => 'getUrl: $host $port $path');
+    // todo (pq): consider same logic as open (but w/ GET added)
+    _todo('getUrl');
     return proxy.get(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> getUrl(Uri url) {
-    _log.log(() => 'getUrl: $url');
+    // todo (pq): consider same logic as open (but w/ GET added)
+    _todo('getUrl');
     return proxy.getUrl(url);
   }
 
   @override
   Future<HttpClientRequest> head(String host, int port, String path) {
-    todo('head');
+    _todo('head');
     return proxy.head(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> headUrl(Uri url) {
-    todo('headUrl');
+    _todo('headUrl');
     return proxy.headUrl(url);
   }
 
   @override
   Future<HttpClientRequest> open(
       String method, String host, int port, String path) {
-    todo('open');
+    _todo('open');
     return proxy.open(method, host, port, path);
   }
 
   @override
   Future<HttpClientRequest> openUrl(String method, Uri url) {
-    final int id = count++;
+    final int id = _count++;
 
     // #1 • GET • https://flutter.io open
-    _log.log(() => '#$id \u2022 $method \u2022 $url open');
+    _log.log(() => '#$id • $method • $url open');
 
     Future<HttpClientRequest> request = proxy.openUrl(method, url);
     return request.then((HttpClientRequest req) {
-      // todo (pq): consider putting id in sequence number?
-      _log.log(() => '#$id \u2022 $method \u2022 $url request ready');
+      _log.log(() => '#$id • $method • $url request ready');
 
       req.done.then((HttpClientResponse response) {
         _log.log(() =>
-            '#$id \u2022 $method \u2022 $url ${response.statusCode} ${response.reasonPhrase} ${response.contentLength} bytes');
+            '#$id • $method • $url ${response.statusCode} ${response.reasonPhrase} ${response.contentLength} bytes');
       });
 
       return req;
@@ -162,43 +181,39 @@ class LoggingHttpClient implements HttpClient {
 
   @override
   Future<HttpClientRequest> patch(String host, int port, String path) {
-    todo('patch');
+    _todo('patch');
     return proxy.patch(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> patchUrl(Uri url) {
-    todo('patchUrl');
+    _todo('patchUrl');
     return proxy.patchUrl(url);
   }
 
   @override
   Future<HttpClientRequest> post(String host, int port, String path) {
-    todo('post');
+    _todo('post');
     return proxy.post(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> postUrl(Uri url) {
-    todo('postUrl');
+    _todo('postUrl');
     return proxy.postUrl(url);
   }
 
   @override
   Future<HttpClientRequest> put(String host, int port, String path) {
-    todo('put');
+    _todo('put');
     return proxy.put(host, port, path);
   }
 
   @override
   Future<HttpClientRequest> putUrl(Uri url) {
-    todo('putUrl');
+    _todo('putUrl');
     return proxy.putUrl(url);
   }
-}
-
-void todo(String msg) {
-  print('TODO: $msg');
 }
 
 class _HttpOverrides extends HttpOverrides {

--- a/lib/src/log_manager.dart
+++ b/lib/src/log_manager.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
+import 'package:logs/src/channels/http_channel.dart';
 import 'package:logs/src/logs.dart';
 import 'package:meta/meta.dart';
 
@@ -16,6 +18,14 @@ typedef void LogListener(String channel, String message, Object data);
 
 typedef _ServiceExtensionCallback = Future<Map<String, dynamic>> Function(
     Map<String, String> parameters);
+
+
+typedef bool _ChannelInstallHandler(String name);
+
+/// Provides hooks for channel installation.
+abstract class ChannelInstallHandler {
+  void installChannel(String name);
+}
 
 /// Exception thrown on logging configuration errors.
 class LoggingException extends Error implements Exception {
@@ -38,8 +48,18 @@ class LogManager {
   Set<String> _enabledChannels = Set<String>();
   final List<LogListener> _logListeners = <LogListener>[];
 
+  final LinkedHashSet<_ChannelInstallHandler> _channelInstallHandlers = LinkedHashSet<_ChannelInstallHandler>();
+
   @visibleForTesting
-  LogManager();
+  LogManager() {
+    _addChannelInstallHandler((name) {
+      if (name == 'http') {
+        installHttpChannel();
+        return true;
+      }
+      return false;
+    });
+  }
 
   /// A map of channels to channel descriptions.
   Map<String, String> get channelDescriptions => _channelDescriptions;
@@ -51,10 +71,8 @@ class LogManager {
   }
 
   void enableLogging(String channel, {bool enable = true}) {
-    if (!_channelDescriptions.containsKey(channel)) {
-      throw LoggingException('channel "$channel" is not registered');
-    }
     enable ? _enabledChannels.add(channel) : _enabledChannels.remove(channel);
+    _installHandlers(channel);
   }
 
   /// Called to register service extensions.
@@ -116,6 +134,15 @@ class LogManager {
   }
 
   bool shouldLog(String channel) => _enabledChannels.contains(channel);
+
+  void _addChannelInstallHandler(_ChannelInstallHandler handler) {
+    _channelInstallHandlers.add(handler);
+  }
+
+  void _installHandlers(String name) {
+    // Install and remove associated handler.
+    _channelInstallHandlers.removeWhere((handler) => handler(name));
+  }
 
   /// Registers a service extension method with the given name and a callback to
   /// be called when the extension method is called.

--- a/lib/src/log_manager.dart
+++ b/lib/src/log_manager.dart
@@ -3,9 +3,10 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer' as developer;
 
-import 'package:logs/src/channels/http_channel.dart';
-import 'package:logs/src/logs.dart';
 import 'package:meta/meta.dart';
+
+import 'channels/http_channel.dart';
+import 'logs.dart';
 
 /// The shared manager instance.
 final LogManager logManager = LogManager()..addListener(_sendToDeveloperLog);
@@ -19,8 +20,7 @@ typedef void LogListener(String channel, String message, Object data);
 typedef _ServiceExtensionCallback = Future<Map<String, dynamic>> Function(
     Map<String, String> parameters);
 
-
-typedef bool _ChannelInstallHandler(String name);
+typedef _ChannelInstallHandler = bool Function(String name);
 
 /// Provides hooks for channel installation.
 abstract class ChannelInstallHandler {
@@ -48,7 +48,8 @@ class LogManager {
   Set<String> _enabledChannels = Set<String>();
   final List<LogListener> _logListeners = <LogListener>[];
 
-  final LinkedHashSet<_ChannelInstallHandler> _channelInstallHandlers = LinkedHashSet<_ChannelInstallHandler>();
+  final LinkedHashSet<_ChannelInstallHandler> _channelInstallHandlers =
+      LinkedHashSet<_ChannelInstallHandler>();
 
   @visibleForTesting
   LogManager() {

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -39,7 +39,10 @@ void main() {
 
     test('enable (unregistered)', () {
       expect(manager.shouldLog('foo'), isFalse);
-      expect(() => manager.enableLogging('foo'), throwsException);
+      // should *not* throw an exception
+      manager.enableLogging('foo');
+      manager.registerChannel('foo');
+      expect(manager.shouldLog('foo'), isTrue);
     });
 
     test('disable', () {


### PR DESCRIPTION
Adds a simple http handler (#6). Cribbed from [flutter dev-tools](https://github.com/flutter/devtools) and very much a WIP but enough to get us iterating.  Sample output:

![image](https://user-images.githubusercontent.com/67586/46870955-f0bdac80-cde4-11e8-8b11-7fab7cc3ba91.png)

Also, tweaks initialization (#30):

* enabling unregistered channels is now ok
* introduces channel initializers, which are called on first access to an unregistered channel

/cc @devoncarew @jacob314

