### PR TITLE
send http headers in openUrl calls

### DIFF
--- a/lib/src/channels/http.dart
+++ b/lib/src/channels/http.dart
@@ -225,7 +225,7 @@ class _HttpOverrides extends HttpOverrides {
 }
 
 Map<String, String> _headersToMap(HttpHeaders headers) {
-  Map<String, String> map = {};
+  final Map<String, String> map = {};
   headers.forEach((String name, List<String> values) {
     map[name] = values.join(',');
   });

--- a/lib/src/log_manager.dart
+++ b/lib/src/log_manager.dart
@@ -5,7 +5,7 @@ import 'dart:developer' as developer;
 
 import 'package:meta/meta.dart';
 
-import 'channels/http_channel.dart';
+import 'channels/http.dart';
 import 'logs.dart';
 
 /// The shared manager instance.


### PR DESCRIPTION
- send http headers in openUrl calls
- rename the `http_channels.dart` file to just `http.dart`

@pq 