### PR TITLE
level and stackTrace params

### DIFF
--- a/lib/src/log_manager.dart
+++ b/lib/src/log_manager.dart
@@ -11,14 +11,23 @@ import 'logs.dart';
 /// The shared manager instance.
 final LogManager logManager = LogManager()..addListener(_sendToDeveloperLog);
 
-void _sendToDeveloperLog(String channel, String message, Object data) {
-  developer.log(message, name: channel, error: data);
+void _sendToDeveloperLog(
+  String channel,
+  String message,
+  Object data,
+  int level,
+  StackTrace stackTrace,
+) {
+  developer.log(message,
+      name: channel, error: data, level: level, stackTrace: stackTrace);
 }
 
 typedef LogListener = void Function(
   String channel,
   String message,
   Object data,
+  int level,
+  StackTrace stackTrace,
 );
 
 typedef _ServiceExtensionCallback = Future<Map<String, dynamic>> Function(
@@ -107,8 +116,14 @@ class LogManager {
             });
   }
 
-  void log(String channel, String message,
-      {Map data, ToJsonEncodable toJsonEncodable}) {
+  void log(
+    String channel,
+    String message, {
+    Map data,
+    ToJsonEncodable toJsonEncodable,
+    int level = 0,
+    StackTrace stackTrace,
+  }) {
     assert(channel != null);
     if (!shouldLog(channel)) {
       return;
@@ -118,7 +133,7 @@ class LogManager {
     String encodedData =
         data != null ? json.encode(data, toEncodable: toJsonEncodable) : null;
     for (int i = 0; i < _logListeners.length; ++i) {
-      _logListeners[i](channel, message, encodedData);
+      _logListeners[i](channel, message, encodedData, level, stackTrace);
     }
   }
 

--- a/lib/src/logs.dart
+++ b/lib/src/logs.dart
@@ -17,13 +17,21 @@ void enableLogging(String channel, {bool enable = true}) {
 /// [enableLogging] or using a VM service call.
 ///
 /// @see enableLogging
-void log(String channel, String message,
-    {Map data, ToJsonEncodable toJsonEncodable}) {
+void log(
+  String channel,
+  String message, {
+  Map data,
+  ToJsonEncodable toJsonEncodable,
+  int level,
+  StackTrace stackTrace,
+}) {
   logManager.log(
     channel,
     message,
     data: data,
     toJsonEncodable: toJsonEncodable,
+    level: level,
+    stackTrace: stackTrace,
   );
 }
 
@@ -52,7 +60,13 @@ class Log {
   }
 
   /// @see [LogManager.log]
-  void log(String message, {Map data, ToJsonEncodable toJsonEncodable}) {
+  void log(
+    String message, {
+    Map data,
+    ToJsonEncodable toJsonEncodable,
+    int level,
+    StackTrace stackTrace,
+  }) {
     logManager.log(
       channel,
       message,

--- a/lib/src/logs_debug.dart
+++ b/lib/src/logs_debug.dart
@@ -16,14 +16,22 @@ typedef LogDataCallback = Map Function();
 /// and [data] will not be evaluated.
 ///
 /// Calls to `debugLog` are removed from release and profile modes.
-void debugLog(String channel, LogMessageCallback messageCallback,
-    {LogDataCallback data, ToJsonEncodable toJsonEncodable}) {
+void debugLog(
+  String channel,
+  LogMessageCallback messageCallback, {
+  LogDataCallback data,
+  ToJsonEncodable toJsonEncodable,
+  int level,
+  StackTrace stackTrace,
+}) {
   assert(() {
     log(
       channel,
       messageCallback(),
       data: data(),
       toJsonEncodable: toJsonEncodable,
+      level: level,
+      stackTrace: stackTrace,
     );
     return true;
   }());

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -7,13 +7,17 @@ void main() {
     String loggedMessage;
     String loggedChannel;
     Object loggedData;
+    int loggedLevel;
+    StackTrace loggedStackTrace;
 
     setUp(() {
       manager = LogManager()
-        ..addListener((channel, message, data) {
+        ..addListener((channel, message, data, level, stackTrace) {
           loggedMessage = message;
           loggedChannel = channel;
           loggedData = data;
+          loggedLevel = level;
+          loggedStackTrace = stackTrace;
         });
     });
 
@@ -70,14 +74,23 @@ void main() {
     test('log', () {
       manager.registerChannel('foo');
       manager.enableLogging('foo');
-      manager.log('foo', 'bar', data: {
-        'x': 1,
-        'y': 2,
-        'z': 3,
-      });
+      final StackTrace testTrace = new StackTrace.fromString('test trace');
+      manager.log(
+        'foo',
+        'bar',
+        data: {
+          'x': 1,
+          'y': 2,
+          'z': 3,
+        },
+        level: 200,
+        stackTrace: testTrace,
+      );
       expect(loggedMessage, 'bar');
       expect(loggedChannel, 'foo');
       expect(loggedData, '{"x":1,"y":2,"z":3}');
+      expect(loggedLevel, 200);
+      expect(loggedStackTrace, testTrace);
     });
   });
 }


### PR DESCRIPTION
adds level and stackTrace named params to the log API.

with this only the 

```dart
  DateTime time,
  int sequenceNumber,
  Zone zone,
```

params from the `developer:log` API remain unexposed.

thoughts on adding them?

/cc @devoncarew 
